### PR TITLE
Rename to "Pluto"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 
-name = "redox"
+name = "pluto"
 version = "0.0.1"
 authors = [
     "bvssvni <bvssvni@gmail.com>"
 ]
+keywords = ["gamedev", "competition", "piston"]
+description = "Server software for Pluto, the Rust gamedev competition"
+license = "MIT"
+repository = "https://github.com/PistonDevelopers/redox.git"
+homepage = "https://github.com/PistonDevelopers/redox"
 
 [[bin]]
 


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/redox/issues/23

Pluto is a planet (dwarf) named after the classical god of the underworld, and
the first letter of many terms originating from it, such as plutonium.

The name is reserved on crates.io, and www.pluto.rs is not taken.